### PR TITLE
Make objectClass attribute comparison case insensitive

### DIFF
--- a/lib/equality_filter.js
+++ b/lib/equality_filter.js
@@ -57,14 +57,27 @@ EqualityFilter.prototype.toString = function () {
 
 
 EqualityFilter.prototype.matches = function (target, strictAttrCase) {
+  var test;
+
   assert.object(target, 'target');
+
+
 
   var tv = helpers.getAttrValue(target, this.attribute, strictAttrCase);
   var value = this.value;
 
-  return helpers.testValues(function (v) {
-    return value === v;
-  }, tv);
+  // do a case insensitive comparison for objectClass attributes.
+  if(this.attribute.toLowerCase() === 'objectclass'){
+    test = function(v){
+      return value.toLowerCase() === v.toLowerCase();
+    }
+  }else{
+    test = function(v){
+      return value === v;
+    }
+  }
+
+  return helpers.testValues(test, tv);
 };
 
 

--- a/test/eq.test.js
+++ b/test/eq.test.js
@@ -128,3 +128,14 @@ test('escape EqualityFilter inputs', function (t) {
   t.equal(f.toString(), '(\\28|\\28foo=bar\\29\\29\\28)');
   t.end();
 });
+
+test('case insensitive match for objectClass attribute', function(t){
+  var f = new EqualityFilter({
+    attribute: 'objectClass',
+    value:     'posixaccount'
+  });
+
+  t.ok(f);
+  t.ok(f.matches({objectClass: 'PoSIxAccount'}));
+  t.end();
+});


### PR DESCRIPTION
Comparisons on the `objectClass` attribute are done according to the rules for `ObjectIdentifier`s comparisons, one of which is that the match should be case insensitive.  There are, in fact, several attribute types for which this is the case, and the equality method is defined by the schema for attributes in general.

The reason it's important to have a 'spot fix' like this is that the subclass of `EqualityFilter` used by ldapjs converts the `value` property of the filter to lower case when the `attribute` property is `objectClass`.  Thus, if my backend returns a record like 

```js
{ 
    objectClass: [posixAccount, shadowAccount]
}
```

the record will not match a filter like `(objectClass=posixAccount)` because of the lower case conversion of the value done by `ldapjs`.

It might be more convenient to change ldapjs to *not* lowercase the `value` property, but it seems like this fix addresses the issue on a deeper level.  I'm not one hundred percent sure on this point, so if it seems different to the maintainers of this project, I'd be happy to discuss a different approach.
