### PR TITLE
Use Buffer instead of String buffer in escapeValue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ function escapeValue(str)
 {
   var cur = 0;
   var len = str.length;
-  var out = '';
+  var out = [];
 
   while (cur < len) {
     var c = str[cur];
@@ -54,19 +54,19 @@ function escapeValue(str)
       if (val.match(hexRegex) === null) {
         throw new Error('invalid escaped char');
       }
-      out += String.fromCharCode(parseInt(val, 16));
+      out.push(Buffer.from(val, "hex"));
       cur += 3;
       break;
 
     default:
       /* Add one regular char */
-      out += c;
+      out.push(Buffer.from(c));
       cur++;
       break;
     }
   }
 
-  return out;
+  return Buffer.concat(out);
 }
 
 function escapeSubstr(str)


### PR DESCRIPTION
String buffer breaks objectGUID filters by encoding raw data in unicode