### PR TITLE
Buffer deprecation fix for DEP0005 in NodeJS

### DIFF
--- a/lib/equality_filter.js
+++ b/lib/equality_filter.js
@@ -18,10 +18,10 @@ function EqualityFilter(options) {
     if (options.raw) {
       this.raw = options.raw;
     } else {
-      this.raw = new Buffer(options.value);
+      this.raw = Buffer.from(options.value);
     }
   } else {
-    this.raw = new Buffer(0);
+    this.raw = Buffer.alloc(0);
   }
 }
 util.inherits(EqualityFilter, helpers.Filter);
@@ -36,9 +36,9 @@ Object.defineProperties(EqualityFilter.prototype, {
     },
     set: function setValue(val) {
       if (typeof (val) === 'string') {
-        this.raw = new Buffer(val);
+        this.raw = Buffer.from(val);
       } else if (Buffer.isBuffer(val)) {
-        this.raw = new Buffer(val.length);
+        this.raw = Buffer.alloc(val.length);
         val.copy(this.raw);
       } else {
         this.raw = val;
@@ -63,7 +63,7 @@ EqualityFilter.prototype.toString = function toString() {
   if (Buffer.isBuffer(this.raw)) {
     value = this.raw;
     decoded = this.raw.toString('utf8');
-    validate = new Buffer(decoded, 'utf8');
+    validate = Buffer.from(decoded, 'utf8');
     /*
      * Use the decoded UTF-8 if it is valid, otherwise fall back to bytes.
      * Since Buffer.compare is missing in older versions of node, a simple

--- a/test/eq.test.js
+++ b/test/eq.test.js
@@ -51,7 +51,7 @@ test('Construct args', function (t) {
 test('construct with raw', function (t) {
   var f = new EqualityFilter({
     attribute: 'foo',
-    raw: new Buffer([240])
+    raw: Buffer.from([240])
   });
   t.ok(f);
   t.ok(f.raw);
@@ -62,11 +62,11 @@ test('construct with raw', function (t) {
 
 test('value setter', function (t) {
   var f = new EqualityFilter();
-  var data = new Buffer([240]);
+  var data = Buffer.from([240]);
   f.value = data;
   t.equal(f.raw[0], data[0], 'preserve buffer');
 
-  data = new Buffer('a');
+  data = Buffer.from('a');
   f.value = data.toString();
   t.equal(f.raw[0], data[0], 'convert string');
 
@@ -133,13 +133,13 @@ test('escape EqualityFilter inputs', function (t) {
   t.equal(f.value, 'bar))(');
   t.equal(f.toString(), '(\\28|\\28foo=bar\\29\\29\\28)');
 
-  f.value = new Buffer([97, 115, 100, 102, 41, 40, 0, 255]);
+  f.value = Buffer.from([97, 115, 100, 102, 41, 40, 0, 255]);
   t.equal(f.toString(), '(\\28|\\28foo=\\61\\73\\64\\66\\29\\28\\00\\ff)');
 
-  f.value = new Buffer([195, 40]);
+  f.value = Buffer.from([195, 40]);
   t.equal(f.toString(), '(\\28|\\28foo=\\c3\\28)');
 
-  f.value = new Buffer([195, 177]);
+  f.value = Buffer.from([195, 177]);
   t.equal(f.toString(), '(\\28|\\28foo=ñ)');
   t.end();
 });


### PR DESCRIPTION
When using the ldapjs package in my NodeJS project I noticed a deprecation message regarding the use of the Node Buffer constructor. I documented the deprecation warning in this issue:

Ref: https://github.com/pfmooney/node-ldap-filter/issues/11

This pull request addresses that problem. I also updated the _new Buffer_ calls in the unit tests as well. All unit tests passed.

The documentation for DEP0005 begins here:

https://nodejs.org/dist/latest-v16.x/docs/api/buffer.html#new-bufferarray